### PR TITLE
Require at least 1.10

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule DllLoaderHelper.MixProject do
     [
       app: :dll_loader_helper,
       version: "0.1.0",
-      elixir: "~> 1.12",
+      elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
       compilers: compilers() ++ Mix.compilers(),
       source_url: @github_url,


### PR DESCRIPTION
The package likely works from even
earlier versions but 1.10 is the earliest
currently supported.