### PR TITLE
Suggestion: deprecate the Elixir version of this project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,3 @@
 # DLLLoaderHelper
 
-[![windows](https://github.com/cocoa-xu/dll_loader_helper/actions/workflows/windows.yml/badge.svg)](https://github.com/cocoa-xu/dll_loader_helper/actions/workflows/windows.yml)
-[![Hex.pm](https://img.shields.io/hexpm/v/dll_loader_helper.svg?style=flat&color=blue)](https://hex.pm/packages/dll_loader_helper)
-
-Add a directory to DLL search path for Windows. 
-
-- `dll_loader_helper_beam` is the Erlang version of this repo.
-- `dll_loader_helper` is the Elixir one.
+This repository is deprecated, use [`dll_loader_helper_beam`](https://github.com/cocoa-xu/dll_loader_helper_beam) instead.


### PR DESCRIPTION
Given the small API, Elixir users should simply invoke the beam version directly.

WDYT?